### PR TITLE
Potential fix for code scanning alert no. 1: Cross-site scripting

### DIFF
--- a/backend/src/main/java/com/urlefy/controller/UrlController.java
+++ b/backend/src/main/java/com/urlefy/controller/UrlController.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.util.Optional;
 
 @RestController
@@ -18,6 +19,6 @@ public class UrlController {
     @PostMapping("/shorten")
     public ResponseEntity<String> shorten(@RequestBody UrlRequest req) {
         String code = service.shortenUrl(req.getUrl(), Optional.ofNullable(req.getCustomAlias()));
-        return ResponseEntity.ok("http://localhost:8080/" + code);
+        return ResponseEntity.ok("http://localhost:8080/" + java.net.URLEncoder.encode(code, "UTF-8"));
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/sxtyxmm/url-shortener/security/code-scanning/1](https://github.com/sxtyxmm/url-shortener/security/code-scanning/1)

To fix the issue, the user-provided input (`req.getCustomAlias()`) must be sanitized or encoded before being included in the response. The best approach is to use a library or utility that performs contextual output encoding for URLs. In Java, the `java.net.URLEncoder` class can be used to encode the `code` variable safely.

Steps to fix:
1. Use `URLEncoder.encode` to encode the `code` variable before including it in the response.
2. Ensure that the encoding is applied consistently to all user-provided inputs that are reflected in the response.

Changes will be made to line 21 in the `shorten` method of `UrlController`.

---

